### PR TITLE
Add support for all haptic feedback types

### DIFF
--- a/Example/index.ios.js
+++ b/Example/index.ios.js
@@ -28,17 +28,49 @@ class Example extends React.Component {
 
           <TouchableHighlight
           style={styles.wrapper}
-          onPress={() => ReactNativeHaptic.generate('impact')}>
+          onPress={() => ReactNativeHaptic.generate('impactHeavy')}>
             <View style={styles.button}>
-              <Text>Impact Feedback</Text>
+              <Text>Impact Heavy</Text>
             </View>
           </TouchableHighlight>
 
           <TouchableHighlight
           style={styles.wrapper}
-          onPress={() => ReactNativeHaptic.generate('notification')}>
+          onPress={() => ReactNativeHaptic.generate('impactMedium')}>
             <View style={styles.button}>
-              <Text>Notification Feedback</Text>
+              <Text>Impact Medium</Text>
+            </View>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+          style={styles.wrapper}
+          onPress={() => ReactNativeHaptic.generate('impactLight')}>
+            <View style={styles.button}>
+              <Text>Impact Light</Text>
+            </View>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+          style={styles.wrapper}
+          onPress={() => ReactNativeHaptic.generate('notificationWarning')}>
+            <View style={styles.button}>
+              <Text>Notification Warning</Text>
+            </View>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+          style={styles.wrapper}
+          onPress={() => ReactNativeHaptic.generate('notificationError')}>
+            <View style={styles.button}>
+              <Text>Notification Error</Text>
+            </View>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+          style={styles.wrapper}
+          onPress={() => ReactNativeHaptic.generate('notificationSuccess')}>
+            <View style={styles.button}>
+              <Text>Notification Success</Text>
             </View>
           </TouchableHighlight>
 
@@ -46,7 +78,7 @@ class Example extends React.Component {
           style={styles.wrapper}
           onPress={() => ReactNativeHaptic.generate('selection')}>
             <View style={styles.button}>
-              <Text>Selection Changed Feedback</Text>
+              <Text>Selection Changed</Text>
             </View>
           </TouchableHighlight>
       </View>

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ I would suggest to run the example directly on your device, since chances are yo
    * @description Triggers haptic feedback of type :type
    * @param type Type of haptic feedback
    */
-    
-    static generate(type: 'impact' | 'notification' | 'selection') {
+
+    static generate(type: 'impact' | 'notification' | 'selection' | 'impactLight' | 'impactMedium' | 'impactHeavy' | 'notificationError' | ' notificationSuccess' | 'notificationWarning') {
       ReactNativeHaptic.generate(type);
     }
   ```


### PR DESCRIPTION
This change adds support for all haptic feedback types on iOS.

Closes #2 

Includes the following changes:
- put notification types into NSString constants for easier organization
- kept support for old "notification/impact/selection" haptics (to avoid breaking older implementations)
- updated README
- updated the example UI to include all notification types

I've left a TODO for how to support the `AudioServicesPlaySystemSound` bits (I've not used that API before, so I dunno what to do there!)